### PR TITLE
Add yajl dependency, bt_value_from_json(), and tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -180,6 +180,17 @@ AC_CHECK_FUNCS([uuid_generate],
 AM_CONDITIONAL([BABELTRACE_BUILD_WITH_LIBUUID], [test "x$link_with_libuuid" = "xyes"])
 AM_CONDITIONAL([BABELTRACE_BUILD_WITH_LIBC_UUID], [test "x$link_with_libc_uuid" = "xyes"])
 
+# Check for yajl
+AX_CHECK_YAJL
+
+if test x$YAJL_2_EXISTS = xyes; then
+	AC_DEFINE_UNQUOTED([BABELTRACE_YAJL_VERSION], 2, [yajl version 1.x])
+elif test x$YAJL_1_EXISTS = xyes; then
+	AC_DEFINE_UNQUOTED([BABELTRACE_YAJL_VERSION], 1, [yajl version 2.x])
+else
+	AC_MSG_ERROR([Cannot find yajl.])
+fi
+
 # Check for fmemopen
 AC_CHECK_LIB([c], [fmemopen],
 [

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -65,6 +65,7 @@ noinst_HEADERS = \
 	babeltrace/ref-internal.h \
 	babeltrace/types.h \
 	babeltrace/object-internal.h \
+	babeltrace/yajl.h \
 	babeltrace/ctf-ir/metadata.h \
 	babeltrace/ctf/events-internal.h \
 	babeltrace/ctf/metadata.h \

--- a/include/babeltrace/values.h
+++ b/include/babeltrace/values.h
@@ -121,10 +121,10 @@ enum bt_value_status {
 
 	/** Invalid arguments. */
 	/* -22 for compatibility with -EINVAL */
-	BT_VALUE_STATUS_INVAL =	-22,
+	BT_VALUE_STATUS_INVAL =		-22,
 
 	/** General error. */
-	BT_VALUE_STATUS_ERROR =	-1,
+	BT_VALUE_STATUS_ERROR =		-1,
 
 	/** Okay, no error. */
 	BT_VALUE_STATUS_OK =		0,

--- a/include/babeltrace/values.h
+++ b/include/babeltrace/values.h
@@ -969,6 +969,20 @@ extern struct bt_value *bt_value_copy(const struct bt_value *object);
 extern bool bt_value_compare(const struct bt_value *object_a,
 		const struct bt_value *object_b);
 
+/**
+ * Returns the value object corresponding to the JSON string
+ * \p json_string.
+ *
+ * JavaScript-style comments are allowed in the JSON string.
+ *
+ * The created map value object's reference count is set to 1.
+ *
+ * @param json_string	JSON string to decode
+ * @returns		Value object built from decoding \p json_string,
+ *			or \c NULL on error
+ */
+extern struct bt_value *bt_value_from_json(const char *json_string);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/babeltrace/yajl.h
+++ b/include/babeltrace/yajl.h
@@ -1,0 +1,120 @@
+#ifndef _BABELTRACE_YAJL_H
+#define _BABELTRACE_YAJL_H
+
+/*
+ * Babeltrace - yajl shim to support yajl 1.x and 2.x
+ *
+ * Copyright (c) 2016 Philippe Proulx <pproulx@efficios.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stddef.h>
+#include <yajl/yajl_parse.h>
+
+#if (BABELTRACE_YAJL_VERSION == 1)
+typedef unsigned int bt_yajl_size_t;
+typedef long bt_yajl_int_value_t;
+
+static inline
+yajl_handle bt_yajl_alloc(const yajl_callbacks *callbacks, void *ctx)
+{
+	yajl_parser_config config = { 0 };
+
+	config.allowComments = 1;
+
+	/* config values are copied by yajl_alloc() */
+	return yajl_alloc(callbacks, &config, NULL, ctx);
+}
+
+static inline
+yajl_status bt_yajl_complete_parse(yajl_handle handle)
+{
+	return yajl_parse_complete(handle);
+}
+
+static inline
+bool bt_yajl_parse_success(yajl_status status)
+{
+	return status == yajl_status_ok ||
+		status == yajl_status_insufficient_data;
+}
+#else
+typedef size_t bt_yajl_size_t;
+typedef long long bt_yajl_int_value_t;
+
+static inline
+yajl_handle bt_yajl_alloc(const yajl_callbacks *callbacks, void *ctx)
+{
+	yajl_handle handle = NULL;
+	int ret;
+
+	handle = yajl_alloc(callbacks, NULL, ctx);
+	if (!handle) {
+		goto end;
+	}
+
+	ret = yajl_config(handle, yajl_allow_comments, 1);
+	if (!ret) {
+		yajl_free(handle);
+		handle = NULL;
+		goto end;
+	}
+
+end:
+	return handle;
+}
+
+static inline
+yajl_status bt_yajl_complete_parse(yajl_handle handle)
+{
+	return yajl_complete_parse(handle);
+}
+
+static inline
+bool bt_yajl_parse_success(yajl_status status)
+{
+	return status == yajl_status_ok;
+}
+#endif /* (BABELTRACE_YAJL_VERSION == 1) */
+
+static inline
+yajl_status bt_yajl_parse(yajl_handle handle, const unsigned char *json_text,
+		bt_yajl_size_t json_text_len)
+{
+	return yajl_parse(handle, json_text, json_text_len);
+}
+
+static inline
+void by_yajl_free(yajl_handle handle)
+{
+	if (!handle) {
+		return;
+	}
+
+	yajl_free(handle);
+}
+
+static inline
+bt_yajl_size_t bt_yajl_get_bytes_consumed(yajl_handle handle)
+{
+	return yajl_get_bytes_consumed(handle);
+}
+
+#endif /* _BABELTRACE_YAJL_H */

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -11,6 +11,7 @@ libbabeltrace_la_SOURCES = babeltrace.c \
 			   trace-collection.c \
 			   registry.c \
 			   values.c \
+			   values-json.c \
 			   ref.c
 
 libbabeltrace_la_LDFLAGS = -version-info $(BABELTRACE_LIBRARY_VERSION)
@@ -19,4 +20,5 @@ libbabeltrace_la_LIBADD = \
 	prio_heap/libprio_heap.la \
 	$(top_builddir)/types/libbabeltrace_types.la \
 	$(top_builddir)/compat/libcompat.la \
-	plugin-system/libplugin-system.la
+	plugin-system/libplugin-system.la \
+	-lyajl

--- a/lib/values-json.c
+++ b/lib/values-json.c
@@ -1,0 +1,581 @@
+/*
+ * Value object <-> JSON
+ *
+ * Babeltrace Library
+ *
+ * Copyright (c) 2016 EfficiOS Inc. and Linux Foundation
+ * Copyright (c) 2016 Philippe Proulx <pproulx@efficios.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <babeltrace/values.h>
+#include <babeltrace/yajl.h>
+#include <glib.h>
+
+struct ctx {
+	GPtrArray *stack;
+	struct bt_value *root_value;
+	bool got_error;
+};
+
+struct stack_frame {
+	struct bt_value *parent;
+	GString *last_map_key;
+};
+
+static
+void stack_destroy_frame(void *data)
+{
+	struct stack_frame *frame = data;
+
+	if (!data) {
+		return;
+	}
+
+	assert(frame);
+	bt_put(frame->parent);
+
+	if (frame->last_map_key) {
+		g_string_free(frame->last_map_key, TRUE);
+	}
+
+	g_free(frame);
+}
+
+static
+void stack_destroy(GPtrArray *stack)
+{
+	if (!stack) {
+		return;
+	}
+
+	g_ptr_array_free(stack, TRUE);
+}
+
+static
+GPtrArray *stack_create(void)
+{
+	return g_ptr_array_new_with_free_func(stack_destroy_frame);
+}
+
+static
+size_t stack_size(GPtrArray *stack)
+{
+	return stack->len;
+}
+
+static
+int stack_push(GPtrArray *stack, struct bt_value *parent)
+{
+	int ret = 0;
+	struct stack_frame *frame;
+
+	frame = g_new0(struct stack_frame, 1);
+	if (!frame) {
+		ret = -1;
+		goto end;
+	}
+
+	frame->last_map_key = g_string_new(NULL);
+	if (!frame->last_map_key) {
+		g_free(frame);
+		frame = NULL;
+		ret = -1;
+		goto end;
+	}
+
+	frame->parent = bt_get(parent);
+	g_ptr_array_add(stack, frame);
+
+end:
+	return ret;
+}
+
+static
+void stack_pop(GPtrArray *stack)
+{
+	assert(stack_size(stack) > 0);
+	g_ptr_array_remove_index(stack, stack_size(stack) - 1);
+}
+
+static
+struct bt_value *stack_peek_parent(GPtrArray *stack)
+{
+	struct stack_frame *frame;
+	assert(stack_size(stack) > 0);
+
+	frame = g_ptr_array_index(stack, stack_size(stack) - 1);
+	assert(frame);
+
+	return frame->parent;
+}
+
+static
+const char *stack_peek_last_map_key(GPtrArray *stack)
+{
+	struct stack_frame *frame;
+	const char *last_map_key = NULL;
+
+	assert(stack_size(stack) > 0);
+	frame = g_ptr_array_index(stack, stack_size(stack) - 1);
+	assert(frame);
+	if (!frame->last_map_key) {
+		goto end;
+	}
+
+	last_map_key = frame->last_map_key->str;
+
+end:
+	return last_map_key;
+}
+
+static
+void stack_peek_set_last_map_key(GPtrArray *stack, const char *key,
+		bt_yajl_size_t key_len)
+{
+	struct stack_frame *frame;
+
+	assert(stack_size(stack) > 0);
+	frame = g_ptr_array_index(stack, stack_size(stack) - 1);
+	assert(frame);
+	g_string_truncate(frame->last_map_key, 0);
+	g_string_append_len(frame->last_map_key, key, key_len);
+}
+
+static
+int stack_peek_insert_into_parent(GPtrArray *stack, struct bt_value *value)
+{
+	int ret = 0;
+	struct bt_value *parent;
+	enum bt_value_status status;
+
+	if (stack_size(stack) == 0) {
+		/* No parent: no place to insert this value */
+		goto end;
+	}
+
+	parent = stack_peek_parent(stack);
+
+	if (bt_value_is_array(parent)) {
+		status = bt_value_array_append(parent, value);
+		if (status != BT_VALUE_STATUS_OK) {
+			ret = -1;
+			goto end;
+		}
+	} else if (bt_value_is_map(parent)) {
+		const char *last_map_key =
+			stack_peek_last_map_key(stack);
+
+		if (!last_map_key) {
+			ret = -1;
+			goto end;
+		}
+
+		status = bt_value_map_insert(parent, last_map_key, value);
+		if (status != BT_VALUE_STATUS_OK) {
+			ret = -1;
+			goto end;
+		}
+	} else {
+		assert(false);
+	}
+
+end:
+	return ret;
+}
+
+static
+int ctx_new_value(struct ctx *ctx, struct bt_value *value)
+{
+	int ret = 0;
+
+	if (stack_size(ctx->stack) == 0) {
+		/* No parent: set as root */
+		bt_put(ctx->root_value);
+		ctx->root_value = bt_get(value);
+	} else {
+		/* Insert into parent */
+		ret = stack_peek_insert_into_parent(ctx->stack, value);
+	}
+
+	return ret;
+}
+
+static
+int handle_null(void *data)
+{
+	int ret = 1;
+	int new_value_ret;
+	struct ctx *ctx = data;
+
+	new_value_ret = ctx_new_value(ctx, bt_value_null);
+	if (new_value_ret) {
+		ret = 0;
+		goto end;
+	}
+
+end:
+	if (!ret) {
+		ctx->got_error = true;
+	}
+
+	return ret;
+}
+
+static
+int handle_boolean(void *data, int bool_val)
+{
+	int ret = 1;
+	int new_value_ret;
+	struct ctx *ctx = data;
+	struct bt_value *value = NULL;
+
+	value = bt_value_bool_create_init(bool_val);
+	if (!value) {
+		ret = 0;
+		goto end;
+	}
+
+	new_value_ret = ctx_new_value(ctx, value);
+	if (new_value_ret) {
+		ret = 0;
+		goto end;
+	}
+
+end:
+	bt_put(value);
+
+	if (!ret) {
+		ctx->got_error = true;
+	}
+
+	return ret;
+}
+
+static
+int parse_int64(const char *input, bt_yajl_size_t input_len, int64_t *val)
+{
+	int ret = -1;
+	int pos;
+
+	ret = sscanf(input, "%" PRId64 "%n", val, &pos);
+	if (ret == 1 && pos == input_len) {
+		ret = 0;
+	}
+
+	return ret;
+}
+
+static
+int parse_double(const char *input, bt_yajl_size_t input_len, double *val)
+{
+	int ret;
+	int pos;
+
+	ret = sscanf(input, "%lf%n", val, &pos);
+	if (ret == 1 && pos == input_len) {
+		ret = 0;
+	}
+
+	return ret;
+}
+
+static
+int handle_number(void *data, const char *number_val, bt_yajl_size_t number_len)
+{
+	int ret = 1;
+	int new_value_ret;
+	struct ctx *ctx = data;
+	struct bt_value *value = NULL;
+	int parse_ret;
+	int64_t int_val;
+	double dbl_val;
+	char buf[64];
+
+	/*
+	 * We try to parse it as a 64-bit signed integer first, which
+	 * is the maximum allowed by an integer value object anyway.
+	 * Otherwise we try to parse it as a floating point number.
+	 *
+	 * The string number_val is not NULL-terminated, so we need to
+	 * copy it to a temporary buffer before using sscanf().
+	 */
+	if (number_len >= sizeof(buf)) {
+		ret = 0;
+		goto end;
+	}
+
+	memcpy(buf, number_val, number_len);
+	buf[number_len] = '\0';
+	parse_ret = parse_int64(buf, number_len, &int_val);
+	if (!parse_ret) {
+		value = bt_value_integer_create_init(int_val);
+		if (!value) {
+			ret = 0;
+			goto end;
+		}
+	} else {
+		parse_ret = parse_double(buf, number_len, &dbl_val);
+		if (parse_ret) {
+			ret = 0;
+			goto end;
+		}
+
+		value = bt_value_float_create_init(dbl_val);
+		if (!value) {
+			ret = 0;
+			goto end;
+		}
+	}
+
+	new_value_ret = ctx_new_value(ctx, value);
+	if (new_value_ret) {
+		ret = 0;
+		goto end;
+	}
+
+end:
+	bt_put(value);
+
+	if (!ret) {
+		ctx->got_error = true;
+	}
+
+	return ret;
+}
+
+static
+int handle_string(void *data, const unsigned char *string_val,
+		bt_yajl_size_t string_len)
+{
+	int ret = 1;
+	int new_value_ret;
+	struct ctx *ctx = data;
+	struct bt_value *value = NULL;
+	char *string;
+
+	/* Convert to C string */
+	string = g_new0(char, string_len + 1);
+	if (!string) {
+		ret = 0;
+		goto end;
+	}
+
+	memcpy(string, string_val, string_len);
+
+	/* Create value */
+	value = bt_value_string_create_init(string);
+	if (!value) {
+		ret = 0;
+		goto end;
+	}
+
+	new_value_ret = ctx_new_value(ctx, value);
+	if (new_value_ret) {
+		ret = 0;
+		goto end;
+	}
+
+end:
+	bt_put(value);
+	g_free(string);
+
+	if (!ret) {
+		ctx->got_error = true;
+	}
+
+	return ret;
+}
+
+static
+int handle_start_map(void *data)
+{
+	int ret = 1;
+	int stack_ret;
+	struct ctx *ctx = data;
+	struct bt_value *value;
+
+	value = bt_value_map_create();
+	if (!value) {
+		ret = 0;
+		goto end;
+	}
+
+	stack_ret = stack_push(ctx->stack, value);
+	if (stack_ret) {
+		ret = 0;
+		goto end;
+	}
+
+end:
+	bt_put(value);
+
+	if (!ret) {
+		ctx->got_error = true;
+	}
+
+	return ret;
+}
+
+static
+int handle_map_key(void *data, const unsigned char *key, bt_yajl_size_t key_len)
+{
+	int ret = 1;
+	struct ctx *ctx = data;
+
+	stack_peek_set_last_map_key(ctx->stack, (const char *) key, key_len);
+
+	return ret;
+}
+
+static
+int handle_end_array_or_map(void *data)
+{
+	int ret = 1;
+	int new_value_ret;
+	struct ctx *ctx = data;
+	struct bt_value *value;
+
+	/* Save current parent (current map) before popping */
+	value = bt_get(stack_peek_parent(ctx->stack));
+	stack_pop(ctx->stack);
+	new_value_ret = ctx_new_value(ctx, value);
+	if (new_value_ret) {
+		ret = 0;
+		goto end;
+	}
+
+end:
+	bt_put(value);
+
+	if (!ret) {
+		ctx->got_error = true;
+	}
+
+	return ret;
+}
+
+static
+int handle_start_array(void *data)
+{
+	int ret = 1;
+	int stack_ret;
+	struct ctx *ctx = data;
+	struct bt_value *value;
+
+	value = bt_value_array_create();
+	if (!value) {
+		ret = 0;
+		goto end;
+	}
+
+	stack_ret = stack_push(ctx->stack, value);
+	if (stack_ret) {
+		ret = 0;
+		goto end;
+	}
+
+end:
+	bt_put(value);
+
+	if (!ret) {
+		ctx->got_error = true;
+	}
+
+	return ret;
+}
+
+static yajl_callbacks callbacks = {
+	.yajl_null = handle_null,
+	.yajl_boolean = handle_boolean,
+	.yajl_integer = NULL,
+	.yajl_double = NULL,
+	.yajl_number = handle_number,
+	.yajl_string = handle_string,
+	.yajl_start_map = handle_start_map,
+	.yajl_map_key = handle_map_key,
+	.yajl_end_map = handle_end_array_or_map,
+	.yajl_start_array = handle_start_array,
+	.yajl_end_array = handle_end_array_or_map,
+};
+
+struct bt_value *bt_value_from_json(const char *json_string)
+{
+	yajl_handle handle = NULL;
+	yajl_status status;
+	size_t json_string_len;
+	bt_yajl_size_t consumed_bytes;
+	struct bt_value *value = NULL;
+	struct ctx ctx = { 0 };
+
+	if (!json_string) {
+		goto end;
+	}
+
+	ctx.stack = stack_create();
+	if (!ctx.stack) {
+		goto end;
+	}
+
+	handle = bt_yajl_alloc(&callbacks, &ctx);
+	if (!handle) {
+		goto end;
+	}
+
+	json_string_len = strlen(json_string);
+	status = bt_yajl_parse(handle, (const unsigned char *) json_string,
+		json_string_len);
+	if (!bt_yajl_parse_success(status)) {
+		goto end;
+	}
+
+	consumed_bytes = bt_yajl_get_bytes_consumed(handle);
+	if (consumed_bytes != json_string_len) {
+		goto end;
+	}
+
+	status = bt_yajl_complete_parse(handle);
+	if (status != yajl_status_ok) {
+		goto end;
+	}
+
+	if (ctx.got_error) {
+		goto end;
+	}
+
+	/* Success: move context's root value to returned value */
+	BT_MOVE(value, ctx.root_value);
+
+end:
+	by_yajl_free(handle);
+	stack_destroy(ctx.stack);
+
+	if (!value) {
+		bt_put(ctx.root_value);
+	}
+
+	return value;
+}

--- a/lib/values.c
+++ b/lib/values.c
@@ -1,5 +1,5 @@
 /*
- * Values.c: value objects
+ * Value objects
  *
  * Babeltrace Library
  *

--- a/m4/ax_check_yajl.m4
+++ b/m4/ax_check_yajl.m4
@@ -1,0 +1,33 @@
+# ax_check_yajl.m4 -- check for YAJL 1.x and 2.x libraries
+#
+# Copyright (C) 2016 - Philippe Proulx <pproulx@efficios.com>
+#
+# This file is free software; the Free Software Foundation gives
+# unlimited permission to copy and/or distribute it, with or without
+# modifications, as long as this notice is preserved.
+
+# This macro checks for YAJL 1.x and 2.x libraries. It sets the
+# following shell variables:
+#
+#   * YAJL_1_EXISTS: "yes" or "no"
+#   * YAJL_2_EXISTS: "yes" or "no"
+
+AC_DEFUN([AX_CHECK_YAJL], [
+    # Check common header
+    AC_CHECK_HEADER([yajl/yajl_common.h],
+                    [yajl_common_header_exists=yes],
+                    [yajl_common_header_exists=no])
+
+    if test x$yajl_common_header_exists = xno; then
+        YAJL_1_EXISTS=no
+        YAJL_2_EXISTS=no
+    else
+        # Check for YAJL 1.x
+        AC_CHECK_LIB([yajl], [yajl_parse_complete],
+                     [YAJL_1_EXISTS=yes], [YAJL_1_EXISTS=no])
+
+        # Check for YAJL 2.x
+        AC_CHECK_LIB([yajl], [yajl_complete_parse],
+                     [YAJL_2_EXISTS=yes], [YAJL_2_EXISTS=no])
+    fi
+])


### PR DESCRIPTION
This one adds a dependency on yajl, either 1.x or 2.x (2.x is preferred). The `m4/ax_check_yajl.m4` macro is responsible for checking the available yajl versions.

A shim is added (`include/babeltrace/yajl.h`) to support both yajl 1.x and 2.x. There are minor differences between the two versions, in particular some integer types and some function names and parameters. All yajl functions should be used in the `bt_` namespace.

This shim is used by the new `lib/values-json.c` to implement `bt_value_from_json()`, a function which converts a JSON string to a value object using yajl. Signed 64-bit integers are supported thanks to using `sscanf()` instead of using the yajl's integer callback, because the 1.x callback has a `long` parameter, which would be 32-bit on a 32-bit build. `sscanf()` is also used to parse double precision floating point numbers.

`bt_value_from_json()` is thoroughly tested (61 new tests) in `tests/lib/test_bt_values.c`.

I built Babeltrace and ran the tests successfully, including a Valgrind memcheck, with the following configurations:

  * yajl 2.1.0, 64-bit
  * yajl 1.0.12, 64-bit
  * yajl 1.0.12, 32-bit